### PR TITLE
CRUD API по рейтингу

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,15 @@ test-metrics-service-ci:
 	docker-compose -f $(COMPOSE_FILE_TEST) --profile metrics-api-test build --build-arg PYTHON_VERSION=$(PYTHON_VERSION)
 	docker-compose -f $(COMPOSE_FILE_TEST) --profile metrics-api-test run --rm tests-metrics-api /bin/bash -c ./tests/functional/start-test.sh
 	docker-compose -f $(COMPOSE_FILE_TEST) --profile metrics-api-test down -v
+
+# -=-=-=-=- Секция content-actions-service -=-=-=-=-
+content-service-up:
+	docker compose -f $(COMPOSE_FILE) --profile production up -d --build content-actions-api mongodb_router $(srv)
+
+# Остановка контейнеров
+content-service-down:
+	docker compose -f $(COMPOSE_FILE) --profile production down content-actions-api redis mongodb_sh1_rep1 mongodb_sh1_rep2 mongodb_sh1_rep3 mongodb_sh2_rep1 mongodb_sh2_rep2 mongodb_sh2_rep3 mongodb_cfg1 mongodb_cfg2 mongodb_cfg3 mongodb_router mongodb_init $(srv)
+
+# Остановка контейнеров и удаление волуме
+content-service-down-v:
+	docker compose -f $(COMPOSE_FILE) --profile production down -v content-actions-api redis mongodb_sh1_rep1 mongodb_sh1_rep2 mongodb_sh1_rep3 mongodb_sh2_rep1 mongodb_sh2_rep2 mongodb_sh2_rep3 mongodb_cfg1 mongodb_cfg2 mongodb_cfg3 mongodb_router mongodb_init $(srv)

--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,6 @@ test-metrics-service-ci:
 content-service-up:
 	docker compose -f $(COMPOSE_FILE) --profile production up -d --build content-actions-api mongodb_router $(srv)
 
-# Остановка контейнеров
-content-service-down:
-	docker compose -f $(COMPOSE_FILE) --profile production down content-actions-api redis mongodb_sh1_rep1 mongodb_sh1_rep2 mongodb_sh1_rep3 mongodb_sh2_rep1 mongodb_sh2_rep2 mongodb_sh2_rep3 mongodb_cfg1 mongodb_cfg2 mongodb_cfg3 mongodb_router mongodb_init $(srv)
-
 # Остановка контейнеров и удаление волуме
 content-service-down-v:
 	docker compose -f $(COMPOSE_FILE) --profile production down -v content-actions-api redis mongodb_sh1_rep1 mongodb_sh1_rep2 mongodb_sh1_rep3 mongodb_sh2_rep1 mongodb_sh2_rep2 mongodb_sh2_rep3 mongodb_cfg1 mongodb_cfg2 mongodb_cfg3 mongodb_router mongodb_init $(srv)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ include:
   - ./infra/clickhouse/docker-compose.clickhouse.yml
   - ./infra/mongodb/docker-compose.mongodb.yml
   - ./services/metric-service/docker-compose.metric-services.yml
-  # - ./services/content-actions-service/docker-compose.content-actions.yml
 
 services:
   elasticsearch:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 include:
   - ./infra/kafka/docker-compose.kafka.yaml
   - ./infra/clickhouse/docker-compose.clickhouse.yml
+  - ./infra/mongodb/docker-compose.mongodb.yml
   - ./services/metric-service/docker-compose.metric-services.yml
-  - ./services/content-actions-service/docker-compose.content-actions.yml
+  # - ./services/content-actions-service/docker-compose.content-actions.yml
 
 services:
   elasticsearch:
@@ -148,6 +149,24 @@ services:
       redis:
         condition: service_healthy
     restart: always
+
+  content-actions-api:
+    build:
+      context: .
+      dockerfile: ./services/content-actions-service/src/Dockerfile
+    env_file:
+      - ./.env
+    ports:
+      - 8099:8000
+    cpus: "1"
+    mem_limit: 256M
+    depends_on:
+      mongodb_init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_healthy
+    restart: always
+
 
 
   admin-panel:

--- a/services/content-actions-service/docker-compose.content-actions.debug.yml
+++ b/services/content-actions-service/docker-compose.content-actions.debug.yml
@@ -16,4 +16,47 @@ services:
     depends_on:
       mongodb_init:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     restart: always
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis-container
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - REDIS_USER=${REDIS_USER}
+      - REDIS_USER_PASSWORD=${REDIS_USER_PASSWORD}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_DB=${REDIS_DB}
+    volumes:
+      - redis_data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    command: >
+      sh -c '
+        mkdir -p /usr/local/etc/redis &&
+        echo "bind 0.0.0.0" > /usr/local/etc/redis/redis.conf &&
+        echo "requirepass $REDIS_PASSWORD" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendonly yes" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendfsync everysec" >> /usr/local/etc/redis/redis.conf &&
+        echo "user default off" > /usr/local/etc/redis/users.acl &&
+        echo "user $REDIS_USER on >$REDIS_USER_PASSWORD ~* +@all" >> /usr/local/etc/redis/users.acl &&
+        redis-server /usr/local/etc/redis/redis.conf --aclfile /usr/local/etc/redis/users.acl
+      '
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "$REDIS_PASSWORD", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: always
+
+volumes:
+  redis_data:

--- a/services/content-actions-service/docker-compose.content-actions.yml
+++ b/services/content-actions-service/docker-compose.content-actions.yml
@@ -5,7 +5,7 @@ services:
   content-actions-api:
     build:
       context: .
-      dockerfile: ./src/Dockerfile
+      dockerfile: ./src/Dockerfile.spare
     env_file:
       - ../../.env
     ports:

--- a/services/content-actions-service/docker-compose.content-actions.yml
+++ b/services/content-actions-service/docker-compose.content-actions.yml
@@ -15,4 +15,47 @@ services:
     depends_on:
       mongodb_init:
         condition: service_completed_successfully
+      redis:
+        condition: service_healthy
     restart: always
+
+  redis:
+    image: redis:7-alpine
+    container_name: redis-container
+    environment:
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - REDIS_USER=${REDIS_USER}
+      - REDIS_USER_PASSWORD=${REDIS_USER_PASSWORD}
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
+      - REDIS_DB=${REDIS_DB}
+    volumes:
+      - redis_data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: '0.50'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+    command: >
+      sh -c '
+        mkdir -p /usr/local/etc/redis &&
+        echo "bind 0.0.0.0" > /usr/local/etc/redis/redis.conf &&
+        echo "requirepass $REDIS_PASSWORD" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendonly yes" >> /usr/local/etc/redis/redis.conf &&
+        echo "appendfsync everysec" >> /usr/local/etc/redis/redis.conf &&
+        echo "user default off" > /usr/local/etc/redis/users.acl &&
+        echo "user $REDIS_USER on >$REDIS_USER_PASSWORD ~* +@all" >> /usr/local/etc/redis/users.acl &&
+        redis-server /usr/local/etc/redis/redis.conf --aclfile /usr/local/etc/redis/users.acl
+      '
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "$REDIS_PASSWORD", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: always
+
+volumes:
+  redis_data:

--- a/services/content-actions-service/src/Dockerfile
+++ b/services/content-actions-service/src/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.12-slim
+ARG PYTHON_VERSION=3.12
+FROM python:${PYTHON_VERSION}-slim
 
 RUN apt-get update && apt-get install -y curl build-essential netcat-openbsd \
     gcc \
@@ -13,21 +14,22 @@ RUN curl -sSL https://install.python-poetry.org | python3 - \
 
 ENV PATH="/root/.local/bin:${PATH}"
 
-COPY src/pyproject.toml src/poetry.lock ./
+# COPY src/pyproject.toml src/poetry.lock ./
+COPY services/content-actions-service/src/pyproject.toml services/content-actions-service/src/poetry.lock ./
 
 # Копируем libs и собираем на месте
-# COPY ../../libs/auth_utils /opt/app/libs/auth_utils
-# RUN cd /opt/app/libs/auth_utils && poetry build && cd /opt/app && poetry add libs/auth_utils
+COPY ../../libs/auth_utils /opt/app/libs/auth_utils
+RUN cd /opt/app/libs/auth_utils && poetry build && cd /opt/app && poetry add libs/auth_utils
 
-# COPY ../../libs/tracer_utils /opt/app/libs/tracer_utils
-# RUN cd /opt/app/libs/tracer_utils && poetry build && cd /opt/app && poetry add libs/tracer_utils
+COPY ../../libs/tracer_utils /opt/app/libs/tracer_utils
+RUN cd /opt/app/libs/tracer_utils && poetry build && cd /opt/app && poetry add libs/tracer_utils
 
-# COPY ../../libs/rate_limite_utils /opt/app/libs/rate_limite_utils
-# RUN cd /opt/app/libs/rate_limite_utils && poetry build && cd /opt/app && poetry add libs/rate_limite_utils
+COPY ../../libs/rate_limite_utils /opt/app/libs/rate_limite_utils
+RUN cd /opt/app/libs/rate_limite_utils && poetry build && cd /opt/app && poetry add libs/rate_limite_utils
 
 RUN poetry install --only main
 
-COPY src/ .
+COPY services/content-actions-service/src/ .
 
 RUN chmod +x ./scripts/entrypoint.sh
 

--- a/services/content-actions-service/src/Dockerfile
+++ b/services/content-actions-service/src/Dockerfile
@@ -14,7 +14,6 @@ RUN curl -sSL https://install.python-poetry.org | python3 - \
 
 ENV PATH="/root/.local/bin:${PATH}"
 
-# COPY src/pyproject.toml src/poetry.lock ./
 COPY services/content-actions-service/src/pyproject.toml services/content-actions-service/src/poetry.lock ./
 
 # Копируем libs и собираем на месте

--- a/services/content-actions-service/src/Dockerfile.spare
+++ b/services/content-actions-service/src/Dockerfile.spare
@@ -1,0 +1,34 @@
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y curl build-essential netcat-openbsd \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/app
+
+RUN curl -sSL https://install.python-poetry.org | python3 - \
+    && export PATH="/root/.local/bin:$PATH" \
+    && poetry config virtualenvs.create false
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+COPY src/pyproject.toml src/poetry.lock ./
+
+# Копируем libs и собираем на месте
+# COPY ../../libs/auth_utils /opt/app/libs/auth_utils
+# RUN cd /opt/app/libs/auth_utils && poetry build && cd /opt/app && poetry add libs/auth_utils
+
+# COPY ../../libs/tracer_utils /opt/app/libs/tracer_utils
+# RUN cd /opt/app/libs/tracer_utils && poetry build && cd /opt/app && poetry add libs/tracer_utils
+
+# COPY ../../libs/rate_limite_utils /opt/app/libs/rate_limite_utils
+# RUN cd /opt/app/libs/rate_limite_utils && poetry build && cd /opt/app && poetry add libs/rate_limite_utils
+
+RUN poetry install --only main
+
+COPY src/ .
+
+RUN chmod +x ./scripts/entrypoint.sh
+
+CMD ["./scripts/entrypoint.sh"]

--- a/services/content-actions-service/src/api/v1/bookmark/bookmark_api.py
+++ b/services/content-actions-service/src/api/v1/bookmark/bookmark_api.py
@@ -1,7 +1,19 @@
 import logging
+from uuid import UUID
 
 from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get(
+    path="/{film_id}/bookmark-test",
+)
+async def test_endpoint_bookmark(
+    film_id: UUID,
+):
+    return {
+        "status": "ok",
+    }

--- a/services/content-actions-service/src/api/v1/like/schemas.py
+++ b/services/content-actions-service/src/api/v1/like/schemas.py
@@ -1,10 +1,22 @@
-from typing import Literal
+from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 
 class LikeRequest(BaseModel):
-    rating: Literal[0, 10] = Field(
+    rating: int = Field(
         ...,
-        description="0 для дизлайка, 10 для лайка.",
+        ge=1,
+        le=10,
+        description="Оценка фильма от 1 до 10.",
     )
+
+
+class ScoreResponse(BaseModel):
+    pass
+
+
+class OutputRating(BaseModel):
+    film_id: UUID = Field(..., alias="_id")
+    rating: float = Field(..., alias="avg_rating")
+    count_votes: int

--- a/services/content-actions-service/src/api/v1/rating/rating_api.py
+++ b/services/content-actions-service/src/api/v1/rating/rating_api.py
@@ -3,22 +3,23 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from api.v1.rating.schemas import OutputRating, ScoreRequest
-from fastapi import APIRouter, Body, status  # ,Depends
+from api.v1.rating.schemas import AvgRatingResponse, ScoreRequest, ScoreResponse
+from fastapi import APIRouter, Body, Depends, status
 from models.models import Rating
-from services.rating_repository import RatingRepository
-from services.rating_service import RatingService  # , get_rating_service
+from services.rating_service import RatingService, get_rating_service
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
+# ! актуальный эндпоинт
 @router.delete(
     path="/{film_id}",
     status_code=status.HTTP_204_NO_CONTENT,
 )
-async def delete_like(
+async def delete_score(
+    rating_service: Annotated[RatingService, Depends(get_rating_service)],
     film_id: UUID,
 ):
     # представим, что у нас в эндпоинте прошла проверка авторизации,
@@ -33,7 +34,7 @@ async def delete_like(
     #     Rating.film_id == film_id
     #     )
     # return Response(status_code=status.HTTP_204_NO_CONTENT)
-    rating_service = RatingService(RatingRepository)
+    # rating_service = RatingService(RatingRepository)
     await rating_service.delete_user_score(
         mock_user_id,
         film_id,
@@ -82,27 +83,27 @@ async def set_tempr_like(
     return {"status": "ok", "result": result}
 
 
+# ! актуальный эндпоинт
 @router.post(
     path="/{film_id}/next-mock-user-id/{user_id}",
     status_code=status.HTTP_200_OK,
 )
 async def set_score(
+    rating_service: Annotated[RatingService, Depends(get_rating_service)],
     film_id: UUID,
     user_id: UUID,
     request_body: Annotated[
         ScoreRequest, Body(description="Данные для добавления лайка в формате JSON")
     ],
-):
+) -> ScoreResponse:
     # result = await RatingRepository.upsert(
     #     Rating.user_id == user_id,
     #     Rating.film_id == film_id,
     #     update_fields=["rating", "lalala"],
-    #     # update_fields=[],
     #     user_id=user_id,
     #     film_id=film_id,
     #     rating=request_body.rating,
     # )
-    rating_service = RatingService(RatingRepository)
     result = await rating_service.set_user_score(
         user_id=user_id,
         film_id=film_id,
@@ -111,52 +112,16 @@ async def set_score(
     return result
 
 
-@router.get(
-    path="/{film_id}/tempr",
-)
-async def get_like(
-    film_id: UUID,
-):
-    # like = await Rating.find_one(Rating.user_id == mock_user_id, Rating.film_id == film_id)
-    # a = 1
-    doc = (
-        await Rating.find(Rating.film_id == film_id)
-        .aggregate(
-            [
-                {
-                    "$group": {
-                        "_id": "$film_id",
-                        "avg_rating": {"$avg": "$score"},
-                        "count_votes": {"$sum": 1},
-                    }
-                }
-            ],
-            projection_model=OutputRating,
-        )
-        .to_list()
-    )
-    if not doc:
-        return None
-    # doc = [
-    # OutputRating(id=UUID('cd4225d4-8087-4a42-aaf7-30a30e8a919d'),
-    # rating=3.0, count_votes=4)]
-    # doc = doc[0]
-    # doc.model_dump()
-    return {
-        "score": doc,
-    }
-
-
 # cd4225d4-8087-4a42-aaf7-30a30e8a919d
 
 
+# ! актуальный эндпоинт
 @router.get(
     path="/{film_id}",
 )
 async def get_avg_rating(
+    rating_service: Annotated[RatingService, Depends(get_rating_service)],
     film_id: UUID,
-    # rating_service: Annotated[RatingService, Depends(get_rating_service)],
-):
-    rating_service = RatingService(RatingRepository)
+) -> AvgRatingResponse | None:
     result = await rating_service.get_average_rating(film_id)
     return result

--- a/services/content-actions-service/src/api/v1/rating/rating_api.py
+++ b/services/content-actions-service/src/api/v1/rating/rating_api.py
@@ -3,11 +3,11 @@ from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
-from api.v1.like.schemas import LikeRequest, OutputRating
+from api.v1.rating.schemas import OutputRating, ScoreRequest
 from fastapi import APIRouter, Body, status  # ,Depends
-from models.models import Like
-from services.like_repository import RatingRepository
-from services.like_service import RatingService  # , get_rating_service
+from models.models import Rating
+from services.rating_repository import RatingRepository
+from services.rating_service import RatingService  # , get_rating_service
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +25,13 @@ async def delete_like(
     # и пользователь с таким UUID
     mock_user_id = UUID("d75589b0-0318-4360-b07a-88944c24bd92")
     # a = 1
-    # doc = await Like.find_one(Like.user_id == mock_user_id, Like.film_id == film_id)
+    # doc = await Rating.find_one(Rating.user_id == mock_user_id, Rating.film_id == film_id)
     # if doc:
     #     await doc.delete()
-    # await RatingRepository.delete_document(Like.user_id == mock_user_id, Like.film_id == film_id)
+    # await RatingRepository.delete_document(
+    #     Rating.user_id == mock_user_id,
+    #     Rating.film_id == film_id
+    #     )
     # return Response(status_code=status.HTTP_204_NO_CONTENT)
     rating_service = RatingService(RatingRepository)
     await rating_service.delete_user_score(
@@ -45,7 +48,7 @@ async def delete_like(
 async def set_tempr_like(
     film_id: UUID,
     request_body: Annotated[
-        LikeRequest, Body(description="Данные для добавления лайка в формате JSON")
+        ScoreRequest, Body(description="Данные для добавления лайка в формате JSON")
     ],
 ):
     # представим, что у нас в эндпоинте прошла проверка авторизации,
@@ -57,23 +60,23 @@ async def set_tempr_like(
         UUID("5580dfe4-9803-4291-8e6b-6e7df27d7032"),
         UUID("8c5d61fa-bcfc-4b91-9ced-5e16da90f4e7"),
     ]
-    like_exist = await Like.find_one(Like.user_id == mock_user_id, Like.film_id == film_id)
-    if like_exist:
-        like_exist.rating = request_body.rating
-        like_exist.updated_at = datetime.now(timezone.utc)
-        result = await like_exist.save()
+    score_exist = await Rating.find_one(Rating.user_id == mock_user_id, Rating.film_id == film_id)
+    if score_exist:
+        score_exist.score = request_body.score
+        score_exist.updated_at = datetime.now(timezone.utc)
+        result = await score_exist.save()
     else:
-        # result = await Like(
+        # result = await Rating(
         #     user_id=UUID("d75589b0-0318-4360-b07a-88944c24bd92"),
         #     film_id=film_id,
         #     rating=request_body.rating,
         # ).insert()
         # ! -=-=-=-=-=-=-=- временный вариант -=-=-=-=-=-=-=-
         for user_id in mock_user_ids:
-            result = await Like(
+            result = await Rating(
                 user_id=user_id,
                 film_id=film_id,
-                rating=request_body.rating,
+                score=request_body.score,
             ).insert()
         # ! -=-=-=-=-=-=-=- временный вариант -=-=-=-=-=-=-=-
     return {"status": "ok", "result": result}
@@ -87,12 +90,12 @@ async def set_score(
     film_id: UUID,
     user_id: UUID,
     request_body: Annotated[
-        LikeRequest, Body(description="Данные для добавления лайка в формате JSON")
+        ScoreRequest, Body(description="Данные для добавления лайка в формате JSON")
     ],
 ):
     # result = await RatingRepository.upsert(
-    #     Like.user_id == user_id,
-    #     Like.film_id == film_id,
+    #     Rating.user_id == user_id,
+    #     Rating.film_id == film_id,
     #     update_fields=["rating", "lalala"],
     #     # update_fields=[],
     #     user_id=user_id,
@@ -103,7 +106,7 @@ async def set_score(
     result = await rating_service.set_user_score(
         user_id=user_id,
         film_id=film_id,
-        rating=request_body.rating,
+        score=request_body.score,
     )
     return result
 
@@ -114,16 +117,16 @@ async def set_score(
 async def get_like(
     film_id: UUID,
 ):
-    # like = await Like.find_one(Like.user_id == mock_user_id, Like.film_id == film_id)
+    # like = await Rating.find_one(Rating.user_id == mock_user_id, Rating.film_id == film_id)
     # a = 1
     doc = (
-        await Like.find(Like.film_id == film_id)
+        await Rating.find(Rating.film_id == film_id)
         .aggregate(
             [
                 {
                     "$group": {
                         "_id": "$film_id",
-                        "avg_rating": {"$avg": "$rating"},
+                        "avg_rating": {"$avg": "$score"},
                         "count_votes": {"$sum": 1},
                     }
                 }
@@ -140,7 +143,7 @@ async def get_like(
     # doc = doc[0]
     # doc.model_dump()
     return {
-        "like": doc,
+        "score": doc,
     }
 
 

--- a/services/content-actions-service/src/api/v1/rating/schemas.py
+++ b/services/content-actions-service/src/api/v1/rating/schemas.py
@@ -20,18 +20,6 @@ class ScoreResponse(BaseModel):
     updated_at: datetime = Field(..., description="Время обновления документа")
     score: float = Field(..., description="Оценка фильма")
 
-    """
-    {
-        "_id": "49602e24-babd-4e33-87b6-fe918edbc68e",
-        "user_id": "d75589b0-0318-4360-b07a-88944c24bd92",
-        "film_id": "4547b202-5f72-4c5e-ae79-9c46f3f95037",
-        "created_at": "2025-06-14T15:21:30.319215Z",
-        "updated_at": "2025-06-14T15:21:30.319219Z",
-        "score": 9
-    }
-    """
-    pass
-
 
 class AvgRatingResponse(BaseModel):
     film_id: UUID = Field(..., description="id пользователя поставившего оценку")

--- a/services/content-actions-service/src/api/v1/rating/schemas.py
+++ b/services/content-actions-service/src/api/v1/rating/schemas.py
@@ -3,8 +3,8 @@ from uuid import UUID
 from pydantic import BaseModel, Field
 
 
-class LikeRequest(BaseModel):
-    rating: int = Field(
+class ScoreRequest(BaseModel):
+    score: int = Field(
         ...,
         ge=1,
         le=10,

--- a/services/content-actions-service/src/api/v1/rating/schemas.py
+++ b/services/content-actions-service/src/api/v1/rating/schemas.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ScoreRequest(BaseModel):
@@ -13,10 +14,30 @@ class ScoreRequest(BaseModel):
 
 
 class ScoreResponse(BaseModel):
+    user_id: UUID = Field(..., description="id пользователя поставившего оценку")
+    film_id: UUID = Field(..., description="id фильма поставившего оценку")
+    created_at: datetime = Field(..., description="Время создания документа")
+    updated_at: datetime = Field(..., description="Время обновления документа")
+    score: float = Field(..., description="Оценка фильма")
+
+    """
+    {
+        "_id": "49602e24-babd-4e33-87b6-fe918edbc68e",
+        "user_id": "d75589b0-0318-4360-b07a-88944c24bd92",
+        "film_id": "4547b202-5f72-4c5e-ae79-9c46f3f95037",
+        "created_at": "2025-06-14T15:21:30.319215Z",
+        "updated_at": "2025-06-14T15:21:30.319219Z",
+        "score": 9
+    }
+    """
     pass
 
 
-class OutputRating(BaseModel):
-    film_id: UUID = Field(..., alias="_id")
-    rating: float = Field(..., alias="avg_rating")
-    count_votes: int
+class AvgRatingResponse(BaseModel):
+    film_id: UUID = Field(..., description="id пользователя поставившего оценку")
+    rating: float = Field(..., description="Средняя оценка фильма")
+    count_votes: int = Field(..., description="Количество оценивших")
+
+    @field_validator("rating")
+    def round_rating(cls, value: float) -> float:
+        return round(value, 2)

--- a/services/content-actions-service/src/api/v1/review/review_api.py
+++ b/services/content-actions-service/src/api/v1/review/review_api.py
@@ -1,7 +1,19 @@
 import logging
+from uuid import UUID
 
 from fastapi import APIRouter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get(
+    path="/{film_id}/review-test",
+)
+async def test_endpoint_review(
+    film_id: UUID,
+):
+    return {
+        "status": "ok",
+    }

--- a/services/content-actions-service/src/core/config.py
+++ b/services/content-actions-service/src/core/config.py
@@ -48,6 +48,7 @@ class AppConfig(BaseSettings):
     docs_url: str = "/content-api/openapi"
     openapi_url: str = "/content-api/openapi.json"
     tracing: bool = False  # включение/выключение трассировки
+    cache_expire_in_seconds: int = 300  # время кэширование ответа (сек.)
 
     redis: Redis = Redis()
     mongodb: MongoDB = MongoDB()

--- a/services/content-actions-service/src/core/config.py
+++ b/services/content-actions-service/src/core/config.py
@@ -21,6 +21,14 @@ class Server(BaseModel):
     worker_class: str = "uvicorn.workers.UvicornWorker"
 
 
+class Redis(BaseModel):
+    host: str = "localhost"
+    port: int = 6379
+    user: str = "redis_user"
+    password: str = "Parol123"
+    db: int = 0
+
+
 class MongoDB(BaseModel):
     host: str = "mongodb_router"
     port: int = 27017
@@ -41,6 +49,7 @@ class AppConfig(BaseSettings):
     openapi_url: str = "/content-api/openapi.json"
     tracing: bool = False  # включение/выключение трассировки
 
+    redis: Redis = Redis()
     mongodb: MongoDB = MongoDB()
     server: Server = Server()
 

--- a/services/content-actions-service/src/db/cache.py
+++ b/services/content-actions-service/src/db/cache.py
@@ -1,0 +1,69 @@
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+
+from redis.asyncio import Redis
+from utils.decorators import redis_handler_exeptions
+
+logger = logging.getLogger(__name__)
+
+cache_conn: Redis | None = None
+
+
+class Cache(ABC):
+    @abstractmethod
+    async def get(self, key: str) -> str | None:
+        pass
+
+    @abstractmethod
+    async def destroy(self, key: str) -> None:
+        pass
+
+    @abstractmethod
+    async def set(self, key: str, value: str, expire: int | None):
+        pass
+
+    @abstractmethod
+    async def background_set(self, key: str, value: str, expire: int | None):
+        pass
+
+    @abstractmethod
+    async def background_destroy(self, key: str) -> None:
+        pass
+
+
+class RedisCache(Cache):
+    def __init__(self, redis: Redis):
+        self.redis = redis
+
+    @redis_handler_exeptions
+    async def get(self, key: str) -> str | None:
+        """Получает кеш из redis"""
+        return await self.redis.get(key)
+
+    @redis_handler_exeptions
+    async def destroy(self, key: str) -> None:
+        await self.redis.delete(key)
+        logger.info(f"[RedisCache] Объект удален по ключу '{key}'")
+
+    @redis_handler_exeptions
+    async def set(self, key: str, value: str, expire: int | None):
+        """Сохраняет кеш в redis"""
+        await self.destroy(key)  # инвалидация кеша
+        await self.redis.set(key, value, ex=expire)
+        logger.info(f"[RedisCache] Объект сохранён в кэш по ключу '{key}'")
+
+    async def background_set(self, key: str, value: str, expire: int | None):
+        """Сохраняет кеш в фоновом процессе"""
+        asyncio.create_task(self.set(key=key, value=value, expire=expire))
+        logger.debug(f"Объект будет сохранен в кеш по {key=}")
+
+    async def background_destroy(self, key: str) -> None:
+        asyncio.create_task(self.destroy(key=key))
+        logger.debug(f"Объект будет удален в кеше по {key=}")
+
+
+async def get_cache() -> Cache:
+    if cache_conn is None:
+        raise ValueError("Cache не инициализирован")
+    return RedisCache(cache_conn)

--- a/services/content-actions-service/src/main.py
+++ b/services/content-actions-service/src/main.py
@@ -1,5 +1,5 @@
 from api.v1.bookmark import bookmark_api
-from api.v1.like import like_api
+from api.v1.rating import rating_api
 from api.v1.review import review_api
 from core.config import app_config
 from fastapi import FastAPI
@@ -31,6 +31,6 @@ app.include_router(bookmark_api.router, prefix=films_prefix, tags=["Заклад
 app.include_router(review_api.router, prefix=films_prefix, tags=["Рецензии"])
 """
 SERVICE_PATH = "/content-api/api/v1/"
-app.include_router(like_api.router, prefix=f"{SERVICE_PATH}likes", tags=["Лайки"])
+app.include_router(rating_api.router, prefix=f"{SERVICE_PATH}rating", tags=["Рейтинг"])
 app.include_router(review_api.router, prefix=f"{SERVICE_PATH}reviews", tags=["Рецензии"])
 app.include_router(bookmark_api.router, prefix=f"{SERVICE_PATH}bookmarks", tags=["Закладки"])

--- a/services/content-actions-service/src/main.py
+++ b/services/content-actions-service/src/main.py
@@ -31,6 +31,6 @@ app.include_router(bookmark_api.router, prefix=films_prefix, tags=["Заклад
 app.include_router(review_api.router, prefix=films_prefix, tags=["Рецензии"])
 """
 SERVICE_PATH = "/content-api/api/v1/"
-app.include_router(rating_api.router, prefix=f"{SERVICE_PATH}rating", tags=["Рейтинг"])
+app.include_router(rating_api.router, prefix=f"{SERVICE_PATH}films-rating", tags=["Рейтинг"])
 app.include_router(review_api.router, prefix=f"{SERVICE_PATH}reviews", tags=["Рецензии"])
 app.include_router(bookmark_api.router, prefix=f"{SERVICE_PATH}bookmarks", tags=["Закладки"])

--- a/services/content-actions-service/src/models/logic_models.py
+++ b/services/content-actions-service/src/models/logic_models.py
@@ -1,0 +1,13 @@
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class AvgRatingSchema(BaseModel):
+    film_id: UUID = Field(..., alias="_id")
+    rating: float = Field(..., alias="avg_rating")
+    count_votes: int
+
+    @field_validator("rating")
+    def round_rating(cls, value: float) -> float:
+        return round(value, 2)

--- a/services/content-actions-service/src/models/models.py
+++ b/services/content-actions-service/src/models/models.py
@@ -27,8 +27,8 @@ class BaseDocument(Document):
     )
 
 
-class Like(BaseDocument):
-    rating: int = Field(..., description="0 для дизлайка, 10 для лайка")
+class Rating(BaseDocument):
+    score: int = Field(..., description="Оценка фильма от 1 до 10.")
 
     class Settings:
         name = app_config.mongodb.like_coll

--- a/services/content-actions-service/src/services/base_repository.py
+++ b/services/content-actions-service/src/services/base_repository.py
@@ -8,18 +8,49 @@ logger = logging.getLogger(__name__)
 
 
 class BaseRepository:
-    collection = None
+    """Базовый репозиторий для CRUD работы с Beanie Document-моделями."""
 
     def __init__(self, model: type[Document]):
+        """
+        Инициализирует репозиторий с указанной Beanie-моделью.
+
+        :param model: Класс модели, наследник beanie.Document.
+        """
+
         self.collection = model
 
     async def get_document(self, *filters: Any) -> Document | None:
+        """
+        Находит один документ по переданным фильтрам.
+
+        :param filters: Условия поиска, например Model.user_id == user_id, Model.film_id == film_id
+        :return: Экземпляр модели Document или None, если не найден.
+        """
+        logger.debug(f"Поиск документа по фильтрам {filters}.")
         return await self.collection.find_one(*filters)
 
     async def insert_document(self, **insert_data: Any) -> Document:
+        """
+        Создаёт новый документ.
+
+        :param insert_data: Поля для создания документа,
+                            например user_id=user_id, film_id=film_id, score=score.
+        :return: Вставленный экземпляр модели Document.
+        """
+
+        logger.debug(f"Создание документа с данными {insert_data}.")
         return await self.collection(**insert_data).insert()
 
     async def update_document(self, document: Document, **update_data: Any) -> Document:
+        """
+        Обновляет поля в переданном экземпляре документа и сохраняет.
+
+        :param document: Ранее полученный экземпляр модели.
+        :param update_data: Поля и новые значения для обновления, например score=new_score.
+        :return: Обновлённый экземпляр модели Document.
+        """
+
+        logger.debug(f"Обновление документа с данными {update_data}.")
         update_field = set(update_data.keys())
         for field in update_field:
             if hasattr(document, field):
@@ -28,16 +59,41 @@ class BaseRepository:
         return await document.save()
 
     async def upsert(self, *filters: Any, **insert_data: Any) -> Document:
-        # a = 1
+        """
+        Если документ по фильтрам найден — обновляет его полями из insert_data,
+        иначе — создаёт новый документ с переданными данными.
+
+        :param filters: Условия поиска для существующего документа,
+                        например Model.user_id == user_id.
+        :param insert_data: Поля для вставки или обновления,
+                            например user_id=user_id, film_id=film_id, score=score.
+        :return: Экземпляр модели Document после операции.
+        """
+
         existing_document = await self.get_document(*filters)
+        logger.debug(
+            "Обновление/создание документа.\n"
+            f" Поиск по фильтрам {filters}.\n"
+            f" Создание/обновление документа с данными {insert_data}."
+        )
         if existing_document:
             return await self.update_document(existing_document, **insert_data)
         else:
             return await self.insert_document(**insert_data)
 
     async def delete_document(self, *filters: Any) -> bool:
+        """
+        Удаляет один документ по переданным фильтрам.
+
+        :param filters: Условия поиска для удаления,
+                        например Model.user_id == user_id, Model.film_id == film_id.
+        :return: True, если документ найден и удалён; False, если не найден.
+        """
+
         document = await self.get_document(*filters)
         if document:
             await document.delete()
+            logger.debug(f"Документ по фильтрам {filters} найден и удалён.")
             return True
+        logger.debug(f"Документ по фильтрам {filters} не найден и не может быть удалён.")
         return False

--- a/services/content-actions-service/src/services/base_repository.py
+++ b/services/content-actions-service/src/services/base_repository.py
@@ -1,0 +1,50 @@
+import logging
+from datetime import datetime, timezone
+
+# from functools import lru_cache
+
+# from beanie import Document
+
+# from api.v1.like.schemas import OutputRating
+# from fastapi import HTTPException, status
+# from models.models import Like
+
+
+logger = logging.getLogger(__name__)
+
+
+class BaseRepository:
+    collection = None
+
+    @classmethod
+    async def get_document(cls, *filters):
+        return await cls.collection.find_one(*filters)
+
+    @classmethod
+    async def insert_document(cls, **insert_data):
+        return await cls.collection(**insert_data).insert()
+
+    @classmethod
+    async def update_document(cls, document, update_field: list, **update_data):
+        for field in update_field:
+            if hasattr(document, field):
+                setattr(document, field, update_data[field])
+        document.updated_at = datetime.now(timezone.utc)
+        return await document.save()
+
+    @classmethod
+    async def upsert(cls, *filters, update_fields: list, **insert_data):
+        # a = 1
+        existing_document = await cls.get_document(*filters)
+        if existing_document:
+            return await cls.update_document(existing_document, update_fields, **insert_data)
+        else:
+            return await cls.insert_document(**insert_data)
+
+    @classmethod
+    async def delete_document(cls, *filters):
+        document = await cls.get_document(*filters)
+        if document:
+            await document.delete()
+            return True
+        return False

--- a/services/content-actions-service/src/services/base_repository.py
+++ b/services/content-actions-service/src/services/base_repository.py
@@ -90,9 +90,9 @@ class BaseRepository:
         :return: True, если документ найден и удалён; False, если не найден.
         """
 
-        document = await self.get_document(*filters)
-        if document:
-            await document.delete()
+        existing_document = await self.get_document(*filters)
+        if existing_document:
+            await existing_document.delete()
             logger.debug(f"Документ по фильтрам {filters} найден и удалён.")
             return True
         logger.debug(f"Документ по фильтрам {filters} не найден и не может быть удалён.")

--- a/services/content-actions-service/src/services/base_repository.py
+++ b/services/content-actions-service/src/services/base_repository.py
@@ -10,6 +10,10 @@ logger = logging.getLogger(__name__)
 class BaseRepository:
     """Базовый репозиторий для CRUD работы с Beanie Document-моделями."""
 
+    __slots__ = [
+        "collection",
+    ]
+
     def __init__(self, model: type[Document]):
         """
         Инициализирует репозиторий с указанной Beanie-моделью.

--- a/services/content-actions-service/src/services/like_repository.py
+++ b/services/content-actions-service/src/services/like_repository.py
@@ -1,0 +1,42 @@
+# from datetime import datetime, timezone
+import logging
+
+from api.v1.like.schemas import OutputRating
+
+# from fastapi import HTTPException, status
+from models.models import Like
+from services.base_repository import BaseRepository
+
+# from functools import lru_cache
+
+# from beanie import Document
+
+
+logger = logging.getLogger(__name__)
+
+
+class RatingRepository(BaseRepository):
+
+    collection = Like
+
+    @classmethod
+    async def calculate_average_rating(cls, *filters):
+        document = (
+            await cls.collection.find(*filters)
+            .aggregate(
+                [
+                    {
+                        "$group": {
+                            "_id": "$film_id",
+                            "avg_rating": {"$avg": "$rating"},
+                            "count_votes": {"$sum": 1},
+                        }
+                    }
+                ],
+                projection_model=OutputRating,
+            )
+            .to_list()
+        )
+        if not document:
+            return None
+        return document

--- a/services/content-actions-service/src/services/like_service.py
+++ b/services/content-actions-service/src/services/like_service.py
@@ -1,0 +1,89 @@
+# import json
+import logging
+
+# from functools import lru_cache
+from uuid import UUID
+
+# from core.config import app_config
+# from fastapi import Depends, HTTPException, status
+from services.like_repository import RatingRepository
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_AVG_RATING = "films:avg_rating:"
+
+
+class RatingService:
+
+    def __init__(
+        self,
+        # cache: Cache,
+        repository: RatingRepository,
+    ):
+        # self.cache = cache
+        self.repository = repository
+
+    async def get_average_rating(self, film_id: UUID):
+        """Возвращает список всех ролей с базовой информацией"""
+        cache_key = f"{CACHE_KEY_AVG_RATING}:{str(film_id)}"
+        avg_rating = None  # await self.cache.get(cache_key)
+
+        if avg_rating:
+            logger.debug(f"Средний арифметический рейтинг фильма получен из кеша: {avg_rating}")
+            cache_key
+            # return [RoleResponse.model_validate(r) for r in json.loads(role_cache)]
+            return "something"
+
+        avg_rating = await self.repository.calculate_average_rating(
+            self.repository.collection.film_id == film_id
+        )
+
+        if not avg_rating:
+            return None
+        result = avg_rating[0].model_dump()
+        # await self.cache.background_set(
+        #     key=cache_key, value=result, expire=app_config.cache_expire_in_seconds
+        # )
+        return result
+
+    async def set_user_score(self, user_id: UUID, film_id: UUID, rating: int):
+        result = await self.repository.upsert(
+            self.repository.collection.user_id == user_id,
+            self.repository.collection.film_id == film_id,
+            update_fields=[
+                "rating",
+            ],
+            # update_fields=["rating", "lalala"],
+            # update_fields=[],
+            user_id=user_id,
+            film_id=film_id,
+            rating=rating,
+        )
+        """
+        {
+            "_id": "4cf5009a-c832-4e0e-b334-cd6109754921",
+            "user_id": "5580dfe4-9803-4291-8e6b-6e7df27d7032",
+            "film_id": "cd4225d4-8087-4a42-aaf7-30a30e8a919d",
+            "created_at": "2025-06-13T18:35:41.593461Z",
+            "updated_at": "2025-06-13T18:35:41.593464Z",
+            "rating": 6
+        }
+        """
+        return result
+
+    async def delete_user_score(self, user_id: UUID, film_id: UUID):
+        await self.repository.delete_document(
+            self.repository.collection.user_id == user_id,
+            self.repository.collection.film_id == film_id,
+        )
+
+
+# @lru_cache()
+# def get_rating_service(
+#     # cache: Cache = Depends(get_cache),
+#     repository: RatingRepository = RatingRepository,
+# ) -> RatingService:
+#     return RatingService(
+#         # cache,
+#         repository
+#     )

--- a/services/content-actions-service/src/services/rating_repository.py
+++ b/services/content-actions-service/src/services/rating_repository.py
@@ -10,8 +10,19 @@ logger = logging.getLogger(__name__)
 
 
 class RatingRepository(BaseRepository):
+    """Репозиторий для работы с рейтингами (модель Rating)."""
 
     async def calculate_average_rating(self, *filters: Any) -> AvgRatingSchema | None:
+        """
+        Вычисляет среднюю оценку и количество голосов по указанным фильтрам.
+
+        :param filters: Условия фильтрации, например Rating.film_id == film_id.
+        :return: Список объектов `AvgRatingSchema`, каждый содержащий:
+                 - film_id (_id из агрегации)
+                 - avg_rating (среднее арифметическое)
+                 - count_votes (число голосов);
+                 или None, если по фильтрам нет документов.
+        """
         document = (
             await self.collection.find(*filters)
             .aggregate(
@@ -29,7 +40,9 @@ class RatingRepository(BaseRepository):
             .to_list()
         )
         if not document:
+            logger.debug(f"Документ по фильтрам {filters} не найден")
             return None
+        logger.debug(f"Документ по фильтрам {filters} найден")
         return document
 
 

--- a/services/content-actions-service/src/services/rating_repository.py
+++ b/services/content-actions-service/src/services/rating_repository.py
@@ -1,10 +1,10 @@
 # from datetime import datetime, timezone
 import logging
 
-from api.v1.like.schemas import OutputRating
+from api.v1.rating.schemas import OutputRating
 
 # from fastapi import HTTPException, status
-from models.models import Like
+from models.models import Rating
 from services.base_repository import BaseRepository
 
 # from functools import lru_cache
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 class RatingRepository(BaseRepository):
 
-    collection = Like
+    collection = Rating
 
     @classmethod
     async def calculate_average_rating(cls, *filters):
@@ -28,7 +28,7 @@ class RatingRepository(BaseRepository):
                     {
                         "$group": {
                             "_id": "$film_id",
-                            "avg_rating": {"$avg": "$rating"},
+                            "avg_rating": {"$avg": "$score"},
                             "count_votes": {"$sum": 1},
                         }
                     }

--- a/services/content-actions-service/src/services/rating_service.py
+++ b/services/content-actions-service/src/services/rating_service.py
@@ -125,6 +125,7 @@ class RatingService:
         logger.debug(
             f"Пользователь - {str(user_id)}\n," f" отозвал оценку фильма {str(film_id)}\n."
         )
+        # if <документ> найден (True), то кешируем, если нет (False), то нет:
         avg_rating = await self.repository.calculate_average_rating(
             self.repository.collection.film_id == film_id
         )

--- a/services/content-actions-service/src/services/rating_service.py
+++ b/services/content-actions-service/src/services/rating_service.py
@@ -15,22 +15,38 @@ CACHE_KEY_AVG_RATING = "films:avg_rating:"
 
 
 class RatingService:
+    """Сервис для работы с рейтингом фильмов."""
 
     def __init__(
         self,
         cache: Cache,
         repository: RatingRepository,
     ):
+        """
+        Инициализирует сервис с кешем и репозиторием.
+
+        :param cache: Экземпляр Cache для кеширования результатов.
+        :param repository: Репозиторий RatingRepository для работы с БД.
+        """
         self.cache = cache
         self.repository = repository
 
     async def get_average_rating(self, film_id: UUID) -> AvgRatingResponse | None:
-        """Возвращает список всех ролей с базовой информацией"""
+        """
+        Возвращает рейтинг фильма
+
+        :param film_id: UUID фильма, для которого нужно получить средний рейтинг.
+        :return: Экземпляр AvgRatingResponse с полями:
+                 - film_id: UUID фильма
+                 - avg_rating: среднее арифметическое оценок (float)
+                 - count_votes: количество голосов (int);
+                 или None, если для фильма нет оценок.
+        """
         cache_key = CACHE_KEY_AVG_RATING + str(film_id)
         avg_rating = await self.cache.get(cache_key)
 
         if avg_rating:
-            logger.debug(f"Средний арифметический рейтинг фильма получен из кеша: {avg_rating}")
+            logger.debug(f"Рейтинг фильма {str(film_id)} получен из кеша по ключу: {cache_key}")
             return AvgRatingResponse.model_validate(json.loads(avg_rating))
 
         avg_rating = await self.repository.calculate_average_rating(
@@ -39,13 +55,29 @@ class RatingService:
 
         if not avg_rating:
             return None
-        result = avg_rating[0].model_dump()
+        result = avg_rating[0]
         await self.cache.background_set(
-            key=cache_key, value=result, expire=app_config.cache_expire_in_seconds
+            key=cache_key, value=result.model_dump_json(), expire=app_config.cache_expire_in_seconds
         )
-        return AvgRatingResponse(**result)
+        logger.debug(f"Рейтинг фильма {str(film_id)} будет сохранён в кеш по ключу {cache_key}.")
+        return AvgRatingResponse(**result.model_dump())
 
     async def set_user_score(self, user_id: UUID, film_id: UUID, score: int) -> ScoreResponse:
+        """
+        Сохраняет/обновляет оценку фильма поставленную авторизованным пользователем.
+
+        :param user_id: UUID пользователя, ставящего оценку.
+        :param film_id: UUID фильма, для которого ставится оценка.
+        :param score: Оценка пользователя (int, строго 1–10).
+        :return: Экземпляр ScoreResponse с полями:
+                 - user_id: UUID пользователя
+                 - film_id: UUID фильма
+                 - created_at: время создания/вставки документа
+                 - updated_at: время последнего обновления
+                 - score: значение оценки
+        """
+
+        cache_key = CACHE_KEY_AVG_RATING + str(film_id)
         document = await self.repository.upsert(
             self.repository.collection.user_id == user_id,
             self.repository.collection.film_id == film_id,
@@ -60,13 +92,48 @@ class RatingService:
             updated_at=document.updated_at,
             score=document.score,
         )
+        logger.debug(
+            f"Пользователь - {str(user_id)}\n,"
+            f" оценил фильм {str(film_id)}\n."
+            f" Оценка: {score}."
+        )
+        avg_rating = await self.repository.calculate_average_rating(
+            self.repository.collection.film_id == film_id
+        )
+        await self.cache.background_set(
+            key=cache_key,
+            value=avg_rating[0].model_dump_json(),
+            expire=app_config.cache_expire_in_seconds,
+        )
+        logger.debug(f"Рейтинг фильма {str(film_id)} будет сохранён в кеш по ключу {cache_key}.")
         return result
 
     async def delete_user_score(self, user_id: UUID, film_id: UUID) -> None:
+        """
+        Удаляет оценку фильма поставленную авторизованным пользователем.
+
+        :param user_id: UUID пользователя.
+        :param film_id: UUID фильма.
+        :return: None.
+        """
+
+        cache_key = CACHE_KEY_AVG_RATING + str(film_id)
         await self.repository.delete_document(
             self.repository.collection.user_id == user_id,
             self.repository.collection.film_id == film_id,
         )
+        logger.debug(
+            f"Пользователь - {str(user_id)}\n," f" отозвал оценку фильма {str(film_id)}\n."
+        )
+        avg_rating = await self.repository.calculate_average_rating(
+            self.repository.collection.film_id == film_id
+        )
+        await self.cache.background_set(
+            key=cache_key,
+            value=avg_rating[0].model_dump_json(),
+            expire=app_config.cache_expire_in_seconds,
+        )
+        logger.debug(f"Рейтинг фильма {str(film_id)} будет сохранён в кеш по ключу {cache_key}.")
 
 
 @lru_cache()

--- a/services/content-actions-service/src/services/rating_service.py
+++ b/services/content-actions-service/src/services/rating_service.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 # from core.config import app_config
 # from fastapi import Depends, HTTPException, status
-from services.like_repository import RatingRepository
+from services.rating_repository import RatingRepository
 
 logger = logging.getLogger(__name__)
 
@@ -46,18 +46,18 @@ class RatingService:
         # )
         return result
 
-    async def set_user_score(self, user_id: UUID, film_id: UUID, rating: int):
+    async def set_user_score(self, user_id: UUID, film_id: UUID, score: int):
         result = await self.repository.upsert(
             self.repository.collection.user_id == user_id,
             self.repository.collection.film_id == film_id,
             update_fields=[
-                "rating",
+                "score",
             ],
-            # update_fields=["rating", "lalala"],
+            # update_fields=["score", "lalala"],
             # update_fields=[],
             user_id=user_id,
             film_id=film_id,
-            rating=rating,
+            score=score,
         )
         """
         {

--- a/services/content-actions-service/src/utils/connectors.py
+++ b/services/content-actions-service/src/utils/connectors.py
@@ -3,7 +3,7 @@ from contextlib import asynccontextmanager
 from beanie import init_beanie
 from core.config import app_config
 from fastapi import FastAPI
-from models.models import Bookmark, Like, Review
+from models.models import Bookmark, Rating, Review
 from motor.motor_asyncio import AsyncIOMotorClient
 
 
@@ -14,7 +14,7 @@ async def lifespan(app: FastAPI):
     await init_beanie(
         database=engine[app_config.mongodb.name],
         document_models=[
-            Like,
+            Rating,
             Review,
             Bookmark,
         ],

--- a/services/content-actions-service/src/utils/connectors.py
+++ b/services/content-actions-service/src/utils/connectors.py
@@ -2,9 +2,11 @@ from contextlib import asynccontextmanager
 
 from beanie import init_beanie
 from core.config import app_config
+from db import cache
 from fastapi import FastAPI
 from models.models import Bookmark, Rating, Review
 from motor.motor_asyncio import AsyncIOMotorClient
+from redis.asyncio import Redis
 
 
 @asynccontextmanager
@@ -20,6 +22,20 @@ async def lifespan(app: FastAPI):
         ],
     )
 
+    cache.cache_conn = Redis(
+        host=app_config.redis.host,
+        port=app_config.redis.port,
+        db=app_config.redis.db,
+        decode_responses=True,
+        username=app_config.redis.user,
+        password=app_config.redis.password,
+        socket_connect_timeout=5,
+        socket_timeout=5,
+        retry_on_error=False,
+        retry_on_timeout=False,
+    )
+
     yield
 
+    await cache.cache_conn.close()
     engine.close()

--- a/services/content-actions-service/src/utils/decorators.py
+++ b/services/content-actions-service/src/utils/decorators.py
@@ -1,0 +1,22 @@
+import logging
+from typing import Any, Callable, Coroutine
+
+from redis.asyncio import ConnectionError, RedisError, TimeoutError
+
+logger = logging.getLogger(__name__)
+
+
+def redis_handler_exeptions[**P, R](
+    func: Callable[P, Coroutine[Any, Any, R]],
+) -> Callable[P, Coroutine[Any, Any, R | None]]:
+    async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R | None:
+        try:
+            return await func(*args, **kwargs)
+        except ConnectionError as error:
+            logger.error(f"[RedisCache] Ошибка соединения: {error}")
+        except TimeoutError as error:
+            logger.error(f"[RedisCache] Timeout соединения: {error}")
+        except RedisError as error:
+            logger.error(f"[RedisCache] Неизвестная ошибка при работе с ключом: {error}")
+
+    return wrapper


### PR DESCRIPTION
# CRUD API rating
### Запуск
Поднять все контейнеры:
```bash
make up
```
Доступен по http://127.0.0.1/content-api/openapi
или необходимые для content-actions-service
```bash
make content-service-up
```
Доступен по http://127.0.0.1:8099/content-api/openapi

---

### Проверка что всё работает:
- нужно поднять все контейнеры
- зарегистрироваться и авторизоваться http://127.0.0.1/auth/openapi
- может быть такое, что регистрация при пустой БД не сработает __(не после моих изменений, так уже было)__, тогда сначала: `docker compose --profile production exec auth-api python manage.py createsuperuser` 
- эндпоинты только для авторизованных пользователей:
  - оценить фильм - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/set_score_content_api_api_v1_films_rating__film_id__post
  - отозвать оценку фильма - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/delete_score_content_api_api_v1_films_rating__film_id__delete
- эндпоинт для всех пользователей : 
  - показать рейтинг фильма (среднее арифметическое) - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/get_avg_rating_content_api_api_v1_films_rating__film_id__rating_get

--- 

### Проверка без авторизации (поднять только необходимые сервисы для content-actions):
- __можно поднять только `make content-service-up`.__
- Временный эндпоинт для проверки:
http://127.0.0.1:8099/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/set_score_content_api_api_v1_films_rating_test_directory__film_id___user_id__post
- Можно передавать uuid для user_id прямо в url.
  - Список валидных uuid:
d75589b0-0318-4360-b07a-88944c24bd92
cd4225d4-8087-4a42-aaf7-30a30e8a919d
5580dfe4-9803-4291-8e6b-6e7df27d7032
4547b202-5f72-4c5e-ae79-9c46f3f95037
- Поставьте оценки одному фильму от разных пользователей, и посмотрите как меняется рейтинг:
http://127.0.0.1:8099/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/get_avg_rating_content_api_api_v1_films_rating__film_id__rating_get

---

### Остановка
Если запустили контейнер через `make content-service-up`, то остановка доступна:
```bash
content-service-down-v
```
Остановка только с удалением томов, т.к. при инициализации монги важно чтобы томов не было