### PR TITLE
Вношу изменения после ревью @Potatoes3212

### DIFF
--- a/services/content-actions-service/src/api/v1/rating/schemas.py
+++ b/services/content-actions-service/src/api/v1/rating/schemas.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
 
 
 class ScoreRequest(BaseModel):
@@ -25,7 +25,4 @@ class AvgRatingResponse(BaseModel):
     film_id: UUID = Field(..., description="id пользователя поставившего оценку")
     rating: float = Field(..., description="Средняя оценка фильма")
     count_votes: int = Field(..., description="Количество оценивших")
-
-    @field_validator("rating")
-    def round_rating(cls, value: float) -> float:
-        return round(value, 2)
+    user_score: int | None

--- a/services/content-actions-service/src/services/base_repository.py
+++ b/services/content-actions-service/src/services/base_repository.py
@@ -10,9 +10,7 @@ logger = logging.getLogger(__name__)
 class BaseRepository:
     """Базовый репозиторий для CRUD работы с Beanie Document-моделями."""
 
-    __slots__ = [
-        "collection",
-    ]
+    __slots__ = ("collection",)
 
     def __init__(self, model: type[Document]):
         """

--- a/services/content-actions-service/src/services/rating_repository.py
+++ b/services/content-actions-service/src/services/rating_repository.py
@@ -12,7 +12,9 @@ logger = logging.getLogger(__name__)
 class RatingRepository(BaseRepository):
     """Репозиторий для работы с рейтингами (модель Rating)."""
 
-    async def calculate_average_rating(self, *filters: Any) -> AvgRatingSchema | None:
+    __slots__ = ("collection",)  # переопределяем в классе наследнике, т.к. __slots__ не наследуется
+
+    async def calculate_average_rating(self, *filters: Any) -> list[AvgRatingSchema] | None:
         """
         Вычисляет среднюю оценку и количество голосов по указанным фильтрам.
 


### PR DESCRIPTION
# CRUD API rating
### Запуск
Поднять все контейнеры:
```bash
make up
```
Доступен по http://127.0.0.1/content-api/openapi
или необходимые для content-actions-service
```bash
make content-service-up
```
Доступен по http://127.0.0.1:8099/content-api/openapi

---

### Проверка что всё работает:
- нужно поднять все контейнеры
- зарегистрироваться и авторизоваться http://127.0.0.1/auth/openapi
- может быть такое, что регистрация при пустой БД не сработает __(не после моих изменений, так уже было)__, тогда сначала: `docker compose --profile production exec auth-api python manage.py createsuperuser` 
- эндпоинты только для авторизованных пользователей:
  - оценить фильм - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/set_score_content_api_api_v1_films_rating__film_id__post
  - отозвать оценку фильма - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/delete_score_content_api_api_v1_films_rating__film_id__delete
- эндпоинт для всех пользователей : 
  - показать рейтинг фильма (среднее арифметическое) - http://127.0.0.1/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/get_avg_rating_content_api_api_v1_films_rating__film_id__rating_get

--- 

### Проверка без авторизации (поднять только необходимые сервисы для content-actions):
- __можно поднять только `make content-service-up`.__
- Временный эндпоинт для проверки:
http://127.0.0.1:8099/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/set_score_content_api_api_v1_films_rating_test_directory__film_id___user_id__post
- Можно передавать uuid для user_id прямо в url.
  - Список валидных uuid:
d75589b0-0318-4360-b07a-88944c24bd92
cd4225d4-8087-4a42-aaf7-30a30e8a919d
5580dfe4-9803-4291-8e6b-6e7df27d7032
4547b202-5f72-4c5e-ae79-9c46f3f95037
- Поставьте оценки одному фильму от разных пользователей, и посмотрите как меняется рейтинг:
http://127.0.0.1:8099/content-api/openapi#/%D0%A0%D0%B5%D0%B9%D1%82%D0%B8%D0%BD%D0%B3/get_avg_rating_content_api_api_v1_films_rating__film_id__rating_get

---

### Остановка
Если запустили контейнер через `make content-service-up`, то остановка доступна:
```bash
content-service-down-v
```
Остановка только с удалением томов, т.к. при инициализации монги важно чтобы томов не было